### PR TITLE
feat(AnimeciX): Add new presence

### DIFF
--- a/websites/A/AnimeciX/metadata.json
+++ b/websites/A/AnimeciX/metadata.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.premid.app/metadata/1.13",
+	"apiVersion": 1,
+	"author": {
+		"id": "858743749240684564",
+		"name": "swesia"
+	},
+	"service": "AnimeciX",
+	"description": {
+		"en": "Best Turkish anime watching website"
+	},
+	"url": "animecix.net",
+	"version": "1.0.0",
+	"logo": "https://discord.do/wp-content/uploads/2023/08/AnimeciX.jpg",
+	"thumbnail": "https://discord.do/wp-content/uploads/2023/08/AnimeciX.jpg",
+	"color": "#FFFFFF",
+	"category": "anime",
+	"tags": [
+		"anime"
+	]
+}

--- a/websites/A/AnimeciX/presence.ts
+++ b/websites/A/AnimeciX/presence.ts
@@ -1,0 +1,140 @@
+const presence = new Presence({
+    clientId: "1336362292622655569"
+});
+
+const browsingTimestamp = Math.floor(Date.now() / 1000);
+
+const enum Assets {
+    Logo = "https://discord.do/wp-content/uploads/2023/08/AnimeciX.jpg",
+    SettingsICO = "https://i.imgur.com/pUucFeP.png",
+}
+
+const observeDOMChanges = (callback: () => void) => {
+    const observer = new MutationObserver(() => {
+        callback();
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+};
+
+const updatePresence = () => {
+    let presenceData: PresenceData = {
+        largeImageKey: Assets.Logo,
+    } as PresenceData;
+
+    presenceData.startTimestamp = browsingTimestamp;
+    presenceData.type = ActivityType.Watching;
+        if (document.location.pathname === "/") {
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Ana Sayfa Görüntüleniyor";
+
+//WATCHİNG PAGE
+    } else if (document.location.pathname.includes("/titles/") && document.location.pathname.includes("/episode/")) {
+        const episodeTitle = document.querySelectorAll(".t-title > .ng-star-inserted")[1]?.textContent;
+        const SEInfo = document.querySelector(".episode-number")?.textContent;
+        // Thumbnail
+        // const animeImgElement = document.querySelector("img.media-image-el");
+        const animeImg = document.querySelector<HTMLElement>("media-item-header")?.style.backgroundImage.match(/url\(["']?(.*?)["']?\)/)?.[1]
+
+        presenceData.largeImageKey = animeImg;
+        presenceData.details = episodeTitle || "Loading";
+        presenceData.state = SEInfo || "Loading";
+
+//EPİSODES PAGE
+    } else if (document.location.pathname.includes("/titles/") && !document.location.pathname.includes("/episode/")) {
+        const animeTitle = document.querySelector(".t-title a")?.textContent;
+        // Thumbnail
+        // const animeImgElement = document.querySelector("img.media-image-el");
+        const animeImg = document.querySelector<HTMLElement>("media-item-header")?.style.backgroundImage.match(/url\(["']?(.*?)["']?\)/)?.[1]
+
+        presenceData.largeImageKey = animeImg;
+        presenceData.details = animeTitle || "Loading";
+        presenceData.state = "Bölümler Görüntüleniyor";
+
+//BROWSE
+    } else if (document.location.pathname === "/browse" && !document.location.pathname.includes("/lists/")) {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Reading;
+        presenceData.smallImageText = "Göz atılıyor.."
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Göz atılıyor..";
+    } else if (document.location.pathname === "/calendar") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Takvim Görüntüleniyor..";
+    } else if (document.location.pathname === "/news") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Haberler Görüntüleniyor..";
+    } else if (document.location.pathname.includes("/users/") ) {
+        const userImg = document.querySelector<HTMLImageElement>(".header > .user-avatar.real")?.src;
+        const userName = document.querySelector(".header > h1.name")?.textContent;
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = userImg;
+        presenceData.smallImageText = userName;
+        presenceData.details = "Kullanıcı görüntüleniyor:";
+        presenceData.state = userName || "Loading..";
+    } else if (document.location.pathname === "/watchlist") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Viewing;
+        presenceData.smallImageText = "Watchlist";
+        presenceData.details = "AnimeciX";
+        presenceData.state = "İzlenenler Görüntüleniyor..";
+    } else if (document.location.pathname === "/lists") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Viewing;
+        presenceData.smallImageText = "İzlenecek Listesi";
+        presenceData.details = "AnimeciX";
+        presenceData.state = "İzleme Listeleri Görüntüleniyor..";
+    } else if (document.location.pathname === "/lists/liked") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Viewing;
+        presenceData.smallImageText = "Favoriler";
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Favoriler Görüntüleniyor..";
+    } else if (document.location.pathname === "/lists/browse") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Reading;
+        presenceData.smallImageText = "Browsing..";
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Oynatma Listeleri Görüntüleniyor..";
+    } else if (document.location.pathname.includes("/lists/") && /\d/.test(document.location.pathname)) {
+        const listname = document.querySelector(".list-name")?.textContent;
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Reading;
+        presenceData.smallImageText = listname || "Loading..";
+        presenceData.details = "Liste Görüntüleniyor:";
+        presenceData.state = listname || "Loading..";
+    } else if (document.location.pathname === "/account/settings") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.SettingsICO;
+        presenceData.smallImageText = "Ayarlar";
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Ayarlar";
+    } else if (document.location.pathname === "/gw-rooms") {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Premiere;
+        presenceData.smallImageText = "Group Watch"
+        presenceData.details = "AnimeciX";
+        presenceData.state = "İzleme Odaları Görüntüleniyor..";
+    } else if (document.location.pathname === "/search/") {
+        const keyword = document.querySelector(".query")?.textContent;
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.smallImageKey = Assets.Search;
+        presenceData.smallImageText = "Aranıyor"
+        presenceData.details = "Aranıyor:";
+        presenceData.state = keyword;
+    } else {
+        presenceData.largeImageKey = Assets.Logo;
+        presenceData.details = "AnimeciX";
+        presenceData.state = "Sayfa Görüntüleniyor.."
+    }
+            
+
+    presence.setActivity(presenceData);
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    updatePresence();
+    observeDOMChanges(updatePresence);
+});


### PR DESCRIPTION
## Description 
Feature: Added Premid presences integration for the Animecix website.

Changes Made:

-Integrated Premid presences to fetch data from the Animecix website's page titles and content.
-Implemented dynamic updates to display the correct anime title and episode information as users watch.
-Provided real-time updates for current page content and the specific episodes being watched.

Additional Information:

-This change aims to enhance the user experience by providing more accurate and personalized information while watching anime.
-The Premid presences feature displays relevant title, episode name, and other related details based on the anime being watched.

Testing:

-Tested with several anime titles and episodes on the Animecix website. Presences are updated correctly.
-Each page has been tested one by one, no issues found.

## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>


![image](https://github.com/user-attachments/assets/06e2bb54-016d-4330-9cd5-6a8be1a2ebc3)
![image](https://github.com/user-attachments/assets/d300f413-22ed-4271-b550-01ab139b5bec)
![image](https://github.com/user-attachments/assets/3bcac6cc-5c04-47a0-9f68-44a1b37f1fc7)
![image](https://github.com/user-attachments/assets/ef30078f-02f1-4a7a-886b-c87ca82eecee)
![image](https://github.com/user-attachments/assets/351c4a56-968d-4022-919a-5df8b1f6ea9a)
![image](https://github.com/user-attachments/assets/931b3052-ee49-4c76-9beb-7fb163f062b9)
![image](https://github.com/user-attachments/assets/13bb3c38-c991-4f53-8385-3c67a949df81)
![image](https://github.com/user-attachments/assets/89787cc6-9221-4e22-aa83-fa59c63ac3a7)
![image](https://github.com/user-attachments/assets/6537e3f1-9a46-4a05-ae36-a1f4a6a16f25)
![image](https://github.com/user-attachments/assets/1e3767da-2310-4ae3-bcac-94c63174d584)


</details>
